### PR TITLE
remove redundant whitespace before punctuation

### DIFF
--- a/src/modules/play/ExerciseInstruction.vue
+++ b/src/modules/play/ExerciseInstruction.vue
@@ -9,7 +9,7 @@ const taskPost = "."
 
 const formattedInstruction = props.instruction
   .replace('{{instruction_pre}}', taskPre)
-  .replace('{{instruction_post}}', taskPost)
+  .replace('{{instruction_post}}', '').trimEnd()+taskPost
 </script>
 
 <template>


### PR DESCRIPTION
This PR resolves:
 #56  
- Removes redundant whitespaces before punctuation at instructions page.
 
 Preview:

![image](https://github.com/user-attachments/assets/2f25a981-333f-4919-bb46-9febcc4a7f7f)
